### PR TITLE
69 signup unit tests

### DIFF
--- a/__tests__/signup.test.ts
+++ b/__tests__/signup.test.ts
@@ -15,6 +15,58 @@ interface User {
 }
 
 describe('createUser', () => {
+  it('Should throw an error for invalid username', async () => {
+    await expect(
+      signupModel.createUser(
+        '',
+        'frogman@test.com',
+        'ba927d96-3b2d-11ee-be256-0242ac120002x',
+      ),
+    ).rejects.toThrowError('Invalid username');
+  });
+
+  it('Should throw an error for empty email', async () => {
+    await expect(
+      signupModel.createUser(
+        'frogman',
+        '',
+        'ba927d96-3b2d-11ee-be256-0242ac120002x',
+      ),
+    ).rejects.toThrowError('Invalid email');
+  });
+  it('Should throw an error for invalid email', async () => {
+    await expect(
+      signupModel.createUser(
+        'frogman',
+        'frogmanAtTestDotCom',
+        'ba927d96-3b2d-11ee-be256-0242ac120002x',
+      ),
+    ).rejects.toThrowError('Invalid email');
+  });
+  it('Should throw an error for invalid UID', async () => {
+    await expect(
+      signupModel.createUser('frogman', 'frogman@test.com', 'inv@l*%-uid'),
+    ).rejects.toThrowError('Invalid UID');
+  });
+  it('Should throw an error for duplicate email', async () => {
+    prismaMock.users.findUnique.mockResolvedValue({
+      id: 1,
+      username: 'existinguser',
+      email: 'frogman@test.com',
+      uid: 'ba927d96-3b2d-11ee-be56-0242ac120002x',
+      created_at: japanTime,
+      updated_at: japanTime,
+    });
+
+    await expect(
+      signupModel.createUser(
+        'frogman',
+        'frogman@test.com',
+        'ba927d96-3b2d-11ee-be256-0242ac120002x',
+      ),
+    ).rejects.toThrowError('Unable to create new user');
+  });
+
   it('Should create a new user', async () => {
     const user: User = {
       id: 1,

--- a/src/model/signup.model.ts
+++ b/src/model/signup.model.ts
@@ -1,6 +1,3 @@
-// import { PrismaClient} from '@prisma/client';
-// const prisma = new PrismaClient();
-
 import { prisma } from '../utils/db.server';
 
 type User = {
@@ -13,6 +10,20 @@ export default {
     email: string,
     uid: string,
   ): Promise<User> {
+    if (username.length < 1) {
+      throw new Error('Invalid username');
+    }
+    if (email.length < 5 || !email.includes('@') || !email.includes('.')) {
+      throw new Error('Invalid email');
+    }
+    if (uid.split('-').length !== 5) {
+      throw new Error('Invalid UID');
+    }
+    for (const char of uid) {
+      if (!/^[a-z0-9-]+$/.test(uid)) {
+        throw new Error('Invalid UID');
+      }
+    }
     const japanTime = new Date().toLocaleString('en-US', {
       timeZone: 'Asia/Tokyo',
     });
@@ -29,6 +40,9 @@ export default {
         username: true,
       },
     });
+    if (!userInfo) {
+      throw new Error('Unable to create new user');
+    }
     return userInfo;
   },
 };


### PR DESCRIPTION
# Description

Write unit tests for signup

# Closes issue(s)

Resolves #69

# How to test
run tests using ```npm test```

# Changes include

1. Add test and corresponding error for empty username
2. Add Add test and corresponding error for invalid email
3. Add Add test and corresponding error for empty or invalid email
4. Add test and corresponding error for UID
5. Add test for email duplicate
6. Add error when createUser returns undefined

# Checklist

- [x] I have tested this code
- [ ] I have updated the README
